### PR TITLE
태스크를 클릭해서 태스크 상세보기 패널 토글

### DIFF
--- a/src/app/styles/_color.scss
+++ b/src/app/styles/_color.scss
@@ -4,3 +4,4 @@ $gray: gray;
 $black: black;
 
 $purple: mediumslateblue;
+$red: red;

--- a/src/features/category-delete/category-delete.ui.tsx
+++ b/src/features/category-delete/category-delete.ui.tsx
@@ -2,7 +2,7 @@ import useCategoryDelete from './category-delete.hook';
 import styles from './category-delete.module.scss';
 
 type TProps = {
-  categoryId?: string;
+  categoryId?: number;
 };
 
 const CategoryDeleteButton = ({ categoryId }: TProps) => {

--- a/src/features/task-detail-show/task-detail-show.module.scss
+++ b/src/features/task-detail-show/task-detail-show.module.scss
@@ -1,7 +1,110 @@
+$detailWidth: 360px;
+
+@mixin boxStyle {
+  border: 1px solid $lightgray;
+  border-radius: 10px;
+  padding: 10px 12px;
+
+  &:focus {
+    outline: none;
+  }
+}
+
 .wrapper {
-  width: 360px;
-  min-width: 360px;
-  padding: 20px;
+  @include flex(start, stretch, column);
+  width: $detailWidth;
+  min-width: $detailWidth;
+
   background-color: $white;
   border-left: 1px solid $black;
+
+  .toolbar {
+    text-align: right;
+    padding: 8px 16px;
+
+    .closeButton {
+      padding: 4px;
+      border-radius: 10px;
+
+      &:hover {
+        background-color: $lightgray;
+      }
+    }
+  }
+
+  .taskWrapper {
+    @include flex(start, stretch, column);
+    flex: 1;
+    gap: 8px;
+    padding: 0 16px;
+    overflow-y: auto;
+
+    .titleWrapper {
+      @include flex(start, center);
+      @include boxStyle;
+      gap: 8px;
+
+      font-size: 18px;
+      font-weight: 600;
+
+      .isCompleted {
+        width: 20px;
+        min-width: 20px;
+        height: 20px;
+        border: 1px solid $gray;
+        border-radius: 50%;
+        background-color: $white;
+      }
+
+      .title {
+        flex: 1;
+      }
+
+      &:has(.isChecked) {
+        .isCompleted {
+          background-color: $purple;
+          border: 1px solid $purple;
+        }
+
+        .title {
+          text-decoration: line-through;
+        }
+      }
+    }
+
+    .expiredAt {
+      @include boxStyle;
+      color: $gray;
+
+      &.hasExpiredAt {
+        color: $red;
+      }
+    }
+
+    .memo {
+      @include boxStyle;
+    }
+  }
+
+  .bottomToolbar {
+    @include flex(start, center);
+    gap: 8px;
+    padding: 8px 16px;
+    border-top: 1px solid $lightgray;
+    color: $gray;
+
+    .createdAt {
+      flex: 1;
+      text-align: center;
+    }
+
+    .deleteButton {
+      padding: 4px;
+      border-radius: 10px;
+
+      &:hover {
+        background-color: $lightgray;
+      }
+    }
+  }
 }

--- a/src/features/task-detail-show/task-detail-show.ui.tsx
+++ b/src/features/task-detail-show/task-detail-show.ui.tsx
@@ -1,9 +1,52 @@
+import { TTask } from '@entities/task';
+
 import styles from './task-detail-show.module.scss';
 
-const TaskDetail = () => {
+type TProps = Omit<TTask, 'id' | 'categoryId'>;
+
+const TaskDetail = ({
+  title,
+  createdAt,
+  expiredAt,
+  isCompleted,
+  memo,
+}: TProps) => {
   return (
     <div className={styles.wrapper}>
-      <p>'태스크 상세보기' 영역</p>
+      <div className={styles.toolbar}>
+        <button
+          className={styles.closeButton}
+          title="태스크 상세보기 닫기 버튼"
+        >
+          ✖️
+        </button>
+      </div>
+      <div className={styles.taskWrapper}>
+        <div className={styles.titleWrapper}>
+          <div
+            className={`${styles.isCompleted} ${
+              isCompleted ? styles.isChecked : ''
+            }`}
+          ></div>
+          <div className={styles.title}>{title}</div>
+        </div>
+        <div
+          className={`${styles.expiredAt} ${
+            expiredAt ? styles.hasExpiredAt : ''
+          }`}
+        >
+          {expiredAt || '기한 설정'}
+        </div>
+        <textarea className={styles.memo} placeholder="메모 추가">
+          {memo}
+        </textarea>
+      </div>
+      <div className={styles.bottomToolbar}>
+        <div className={styles.createdAt}>{createdAt}</div>
+        <button className={styles.deleteButton} title="태스크 삭제 버튼">
+          🗑️
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/features/task-list-show/task-list-show.hook.ts
+++ b/src/features/task-list-show/task-list-show.hook.ts
@@ -1,7 +1,7 @@
 import { type TTask, getTaskListFromDB, useTaskContext } from '@entities/task';
 
 const useTaskListShow = () => {
-  const { taskList, setTaskList } = useTaskContext();
+  const { setTaskList } = useTaskContext();
 
   const getTaskList = async (categoryId: number) => {
     try {
@@ -23,7 +23,6 @@ const useTaskListShow = () => {
   };
 
   return {
-    taskList,
     getTaskList,
   };
 };

--- a/src/features/task-list-show/task-list-show.ui.tsx
+++ b/src/features/task-list-show/task-list-show.ui.tsx
@@ -5,7 +5,7 @@ import styles from './task-list-show.module.scss';
 import { useEffect } from 'react';
 
 type TProps = {
-  categoryId?: string;
+  categoryId?: number;
 };
 
 const TaskList = ({ categoryId }: TProps) => {

--- a/src/features/task-list-show/task-list-show.ui.tsx
+++ b/src/features/task-list-show/task-list-show.ui.tsx
@@ -1,4 +1,4 @@
-import { Task } from '@entities/task';
+import { Task, TTask, useTaskContext } from '@entities/task';
 
 import useTaskListShow from './task-list-show.hook';
 import styles from './task-list-show.module.scss';
@@ -9,7 +9,18 @@ type TProps = {
 };
 
 const TaskList = ({ categoryId }: TProps) => {
-  const { taskList, getTaskList } = useTaskListShow();
+  const { getTaskList } = useTaskListShow();
+  const { taskList, setSelectedTask } = useTaskContext();
+
+  const handleTaskClick = (task: TTask) => {
+    setSelectedTask((prevTask) => {
+      if (prevTask?.id === task.id) {
+        return undefined;
+      }
+
+      return task;
+    });
+  };
 
   useEffect(() => {
     if (!categoryId) return;
@@ -19,7 +30,11 @@ const TaskList = ({ categoryId }: TProps) => {
   return (
     <div className={styles.wrapper}>
       {taskList.map((task) => (
-        <Task key={task.id} title={task.title} onClick={() => {}} />
+        <Task
+          key={task.id}
+          title={task.title}
+          onClick={() => handleTaskClick(task)}
+        />
       ))}
     </div>
   );

--- a/src/widgets/task-section/task-section.ui.tsx
+++ b/src/widgets/task-section/task-section.ui.tsx
@@ -2,14 +2,16 @@ import { CategoryHeader } from '@features/category-header-show';
 import { CategoryDeleteButton } from '@features/category-delete';
 import { TaskList } from '@features/task-list-show';
 import { TaskAddInputBar } from '@features/task-add';
+import { TaskDetail } from '@features/task-detail-show';
 
 import { useCategoryContext } from '@entities/category';
+import { useTaskContext } from '@entities/task';
 
 import styles from './task-section.module.scss';
 
 const TaskSection = () => {
   const { selectedCategory } = useCategoryContext();
-  // const { isVisible, handleToggle } = useToggleTaskDetail();
+  const { selectedTask } = useTaskContext();
 
   return (
     <div className={styles.wrapper}>
@@ -27,7 +29,15 @@ const TaskSection = () => {
           </>
         )}
       </div>
-      {/* {isVisible && <TaskDetail />} */}
+      {selectedTask && (
+        <TaskDetail
+          title={selectedTask.title}
+          createdAt={selectedTask.createdAt}
+          expiredAt={selectedTask?.expiredAt}
+          isCompleted={selectedTask.isCompleted}
+          memo={selectedTask?.memo}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- 태스크를 클릭해서 해당 태스크의 상세보기 패널을 조회할 수 있다.
  - 태스크를 클릭해서 태스크 상세보기 패널 토글 기능 추가
  - 태스크 상세보기 패널 UI 추가
    - 내부 UI 동작은 추후 구현 예정 
- 기존 PR에서 변경한 타입 중 누락된 타입 수정
  - id를 string > number로 수정

<br />

## 개발자 테스트

태스크 A와 B를 생성한다.
- [x] 태스크 A를 클릭하면, 태스크 A의 상세보기 패널이 뜬다.
- [x] 태스크 A의 상세보기 패널이 떠있는 상태에서, 한 번 더 태스크 A를 클릭하면 상세보기 패널이 닫긴다.
- [x] 태스크 A의 상세보기 패널이 떠있는 상태에서, 태스크 B를 클릭하면 태스크 B의 상세보기 패널로 교체된다.

<br />

## 스크린샷

https://github.com/user-attachments/assets/2df7134c-9d89-41e8-9730-a3d0181938fe
