### PR TITLE
태스크 상세보기 패널 닫기 컴포넌트 분리, 기능 추가

### DIFF
--- a/src/features/task-detail-close/index.ts
+++ b/src/features/task-detail-close/index.ts
@@ -1,0 +1,1 @@
+export { default as TaskDetailCloseButton } from './ui';

--- a/src/features/task-detail-close/ui.module.scss
+++ b/src/features/task-detail-close/ui.module.scss
@@ -1,0 +1,8 @@
+.closeButton {
+  padding: 4px;
+  border-radius: 10px;
+
+  &:hover {
+    background-color: $lightgray;
+  }
+}

--- a/src/features/task-detail-close/ui.tsx
+++ b/src/features/task-detail-close/ui.tsx
@@ -1,0 +1,22 @@
+import { useTaskContext } from '@entities/task';
+import styles from './ui.module.scss';
+
+const TaskDetailCloseButton = () => {
+  const { setSelectedTask } = useTaskContext();
+
+  const handleClose = () => {
+    setSelectedTask(undefined);
+  };
+
+  return (
+    <button
+      className={styles.closeButton}
+      title="태스크 상세보기 닫기 버튼"
+      onClick={handleClose}
+    >
+      ✖️
+    </button>
+  );
+};
+
+export default TaskDetailCloseButton;

--- a/src/widgets/task-detail/task-detail.module.scss
+++ b/src/widgets/task-detail/task-detail.module.scss
@@ -18,15 +18,6 @@ $detailWidth: 360px;
   .toolbar {
     text-align: right;
     padding: 8px 16px;
-
-    .closeButton {
-      padding: 4px;
-      border-radius: 10px;
-
-      &:hover {
-        background-color: $lightgray;
-      }
-    }
   }
 
   .taskWrapper {

--- a/src/widgets/task-detail/task-detail.ui.tsx
+++ b/src/widgets/task-detail/task-detail.ui.tsx
@@ -1,3 +1,5 @@
+import { TaskDetailCloseButton } from '@features/task-detail-close';
+
 import { TTask } from '@entities/task';
 
 import styles from './task-detail.module.scss';
@@ -14,12 +16,7 @@ const TaskDetail = ({
   return (
     <div className={styles.wrapper}>
       <div className={styles.toolbar}>
-        <button
-          className={styles.closeButton}
-          title="태스크 상세보기 닫기 버튼"
-        >
-          ✖️
-        </button>
+        <TaskDetailCloseButton />
       </div>
       <div className={styles.taskWrapper}>
         <div className={styles.titleWrapper}>


### PR DESCRIPTION
- 태스크 상세보기 패널 닫기 기능 추가
  - 기존 UI를 `<TaskDetailCloseButton />`로 분리
  - 패널 닫기 로직 추가

<br />

## 개발자 테스트

- [x] 태스크를 클릭하여 태스크 상세보기 패널을 연 상태에서, 태스크 상세보기 패널 우측 상단의 [X] 버튼을 클릭하여 상세보기 패널을 닫을 수 있다.

<br />

## 스크린샷 

https://github.com/user-attachments/assets/7e2b7b6d-50a7-499c-8d0e-8d2b3176c448



