### PR TITLE
카테고리가 없을 때 빈 화면처럼 보이는 현상 수정

### DIFF
--- a/src/features/category-delete/category-delete.ui.tsx
+++ b/src/features/category-delete/category-delete.ui.tsx
@@ -2,15 +2,19 @@ import useCategoryDelete from './category-delete.hook';
 import styles from './category-delete.module.scss';
 
 type TProps = {
-  categoryId?: number;
+  categoryId: number;
+  categoryTitle?: string;
 };
 
-const CategoryDeleteButton = ({ categoryId }: TProps) => {
+const CategoryDeleteButton = ({ categoryId, categoryTitle }: TProps) => {
   const { deleteCategory } = useCategoryDelete();
 
   const handleCategoryDeleteButtonClick = () => {
     if (!categoryId) return;
-    deleteCategory(categoryId);
+
+    if (window.confirm(`🚨 '${categoryTitle}'를 영구적으로 삭제합니다.`)) {
+      deleteCategory(categoryId);
+    }
   };
 
   return (

--- a/src/pages/main/main.ui.tsx
+++ b/src/pages/main/main.ui.tsx
@@ -15,12 +15,10 @@ const MainPage = () => {
     <div className={styles.wrapper}>
       <Sidebar />
       <div className={styles.taskWrapper}>
-        {selectedCategory && (
-          <TaskSection
-            selectedCategoryId={selectedCategory.id}
-            selectedCategoryTitle={selectedCategory.title}
-          />
-        )}
+        <TaskSection
+          selectedCategoryId={selectedCategory?.id}
+          selectedCategoryTitle={selectedCategory?.title}
+        />
         {selectedTask && (
           <TaskDetail
             title={selectedTask.title}

--- a/src/widgets/task-section/no-category/index.ts
+++ b/src/widgets/task-section/no-category/index.ts
@@ -1,0 +1,1 @@
+export { default as NoCategory } from './ui';

--- a/src/widgets/task-section/no-category/ui.module.scss
+++ b/src/widgets/task-section/no-category/ui.module.scss
@@ -1,0 +1,15 @@
+.noCategoryWrapper {
+  @include flex(center, center, column);
+  flex: 1;
+  background-color: $purple;
+  border-top-left-radius: 10px;
+
+  .image {
+    font-size: 80px;
+  }
+  .desc {
+    margin-top: 8px;
+    text-align: center;
+    color: $white;
+  }
+}

--- a/src/widgets/task-section/no-category/ui.module.scss
+++ b/src/widgets/task-section/no-category/ui.module.scss
@@ -1,8 +1,8 @@
+@import '../ui.mixin.scss';
+
 .noCategoryWrapper {
   @include flex(center, center, column);
-  flex: 1;
-  background-color: $purple;
-  border-top-left-radius: 10px;
+  @include backgroundStyle;
 
   .image {
     font-size: 80px;

--- a/src/widgets/task-section/no-category/ui.tsx
+++ b/src/widgets/task-section/no-category/ui.tsx
@@ -1,0 +1,16 @@
+import styles from './ui.module.scss';
+
+const NoCategory = () => {
+  return (
+    <div className={styles.noCategoryWrapper}>
+      <div className={styles.image}>😶‍🌫️</div>
+      <div className={styles.desc}>
+        카테고리를 추가하고
+        <br />
+        태스크를 관리해보세요.
+      </div>
+    </div>
+  );
+};
+
+export default NoCategory;

--- a/src/widgets/task-section/task-section.module.scss
+++ b/src/widgets/task-section/task-section.module.scss
@@ -1,6 +1,6 @@
+@import './ui.mixin.scss';
+
 .wrapper {
   @include flex(start, stretch, column);
-  flex: 1;
-  background-color: $purple;
-  border-top-left-radius: 10px;
+  @include backgroundStyle;
 }

--- a/src/widgets/task-section/task-section.ui.tsx
+++ b/src/widgets/task-section/task-section.ui.tsx
@@ -23,7 +23,10 @@ const TaskSection = ({ selectedCategoryId, selectedCategoryTitle }: TProps) => {
             categoryId={selectedCategoryId}
             categoryTitle={selectedCategoryTitle}
           >
-            <CategoryDeleteButton categoryId={selectedCategoryId} />
+            <CategoryDeleteButton
+              categoryId={selectedCategoryId}
+              categoryTitle={selectedCategoryTitle}
+            />
           </CategoryHeader>
           <TaskList categoryId={selectedCategoryId} />
           <TaskAddInputBar />

--- a/src/widgets/task-section/task-section.ui.tsx
+++ b/src/widgets/task-section/task-section.ui.tsx
@@ -3,6 +3,7 @@ import { CategoryDeleteButton } from '@features/category-delete';
 import { TaskList } from '@features/task-list-show';
 import { TaskAddInputBar } from '@features/task-add';
 import styles from './task-section.module.scss';
+import { NoCategory } from './no-category';
 
 type TProps = {
   selectedCategoryId?: number;
@@ -10,18 +11,22 @@ type TProps = {
 };
 
 const TaskSection = ({ selectedCategoryId, selectedCategoryTitle }: TProps) => {
+  if (!selectedCategoryId) {
+    return <NoCategory />;
+  }
+
   return (
     <div className={styles.wrapper}>
       {selectedCategoryId && (
         <>
-      <CategoryHeader
-        categoryId={selectedCategoryId}
-        categoryTitle={selectedCategoryTitle}
-      >
-        <CategoryDeleteButton categoryId={selectedCategoryId} />
-      </CategoryHeader>
-      <TaskList categoryId={selectedCategoryId} />
-      <TaskAddInputBar />
+          <CategoryHeader
+            categoryId={selectedCategoryId}
+            categoryTitle={selectedCategoryTitle}
+          >
+            <CategoryDeleteButton categoryId={selectedCategoryId} />
+          </CategoryHeader>
+          <TaskList categoryId={selectedCategoryId} />
+          <TaskAddInputBar />
         </>
       )}
     </div>

--- a/src/widgets/task-section/task-section.ui.tsx
+++ b/src/widgets/task-section/task-section.ui.tsx
@@ -5,13 +5,15 @@ import { TaskAddInputBar } from '@features/task-add';
 import styles from './task-section.module.scss';
 
 type TProps = {
-  selectedCategoryId: number;
-  selectedCategoryTitle: string;
+  selectedCategoryId?: number;
+  selectedCategoryTitle?: string;
 };
 
 const TaskSection = ({ selectedCategoryId, selectedCategoryTitle }: TProps) => {
   return (
     <div className={styles.wrapper}>
+      {selectedCategoryId && (
+        <>
       <CategoryHeader
         categoryId={selectedCategoryId}
         categoryTitle={selectedCategoryTitle}
@@ -20,6 +22,8 @@ const TaskSection = ({ selectedCategoryId, selectedCategoryTitle }: TProps) => {
       </CategoryHeader>
       <TaskList categoryId={selectedCategoryId} />
       <TaskAddInputBar />
+        </>
+      )}
     </div>
   );
 };

--- a/src/widgets/task-section/ui.mixin.scss
+++ b/src/widgets/task-section/ui.mixin.scss
@@ -1,0 +1,5 @@
+@mixin backgroundStyle {
+  flex: 1;
+  background-color: $purple;
+  border-top-left-radius: 10px;
+}


### PR DESCRIPTION
- 문제
  - 카테고리가 하나도 없을 때, 빈 화면처럼 보이는 현상이 있음
  - 사용자가 어떤 상황인지 파악하기 힘든 문제가 있음.
- 원인
  - 선택된 카테고리가 없을 때 태스크 영역 전체를 보여주지 않도록 해둠
- 해결
  - 선택된 카테고리가 없을 때 태스크 영역 전체가 아닌 카테고리 제목, 카테고리 삭제 버튼, 태스크 추가 인풋 UI만 보여지지 않도록 처리
  - 카테고리 삭제 버튼 클릭 시, 삭제 전 확인 단계를 거치도록 window.confirm 추가
  - 카테고리가 없을 때 안내 문구 추가

<br />

## 개발자 테스트

카테고리를 하나 생성한다.

- [x] 카테고리를 생성 > 선택한 후, 카테고리 삭제 버튼을 클릭하면 카테고리 삭제 확인창을 보여준다. [확인] 버튼을 클릭하고 카테고리를 삭제할 수 있다.
- [x] 카테고리가 하나도 없을 때, 태스크 섹션 영역에 안내 문구('카테고리를 추가하고
태스크를 관리해보세요.')를 보여준다.

<br />  

## 스크린샷

전

https://github.com/user-attachments/assets/3bef12f4-0e2e-4f8e-93dd-5319f85769f9

후

https://github.com/user-attachments/assets/82890ba8-ab3f-48f0-bbaf-4003ca4fef49