### PR TITLE
카테고리 삭제 시 모든 하위 태스크를 함께 삭제

### DIFF
--- a/src/entities/category/category.db.ts
+++ b/src/entities/category/category.db.ts
@@ -2,34 +2,25 @@ import type { TCategory, TNewCatergory } from './category.type';
 import { EStoreName, ETransactionMode, initDB } from '@shared/db';
 
 export const getCategoryListFromDB = async (): Promise<TCategory[]> => {
-  const db = await initDB({
-    storeName: EStoreName.categoryList,
-    transactionMode: ETransactionMode.readonly,
-  });
+  const db = await openDB();
+  const store = db
+    .transaction(EStoreName.categoryList, ETransactionMode.readonly)
+    .objectStore(EStoreName.categoryList);
 
-  return new Promise((resolve, reject) => {
-    const request = db.getAll();
-
-    request.onsuccess = () => {
-      resolve(request.result);
-    };
-
-    request.onerror = () => {
-      reject(request.error);
-    };
+    const request = store.getAll();
   });
 };
 
 export const addCategoryToDB = async (
   newCategory: TNewCatergory
 ): Promise<TCategory> => {
-  const db = await initDB({
-    storeName: EStoreName.categoryList,
-    transactionMode: ETransactionMode.readwrite,
-  });
+  const db = await openDB();
+  const store = db
+    .transaction(EStoreName.categoryList, ETransactionMode.readwrite)
+    .objectStore(EStoreName.categoryList);
 
   return new Promise((resolve, reject) => {
-    const request = db.add(newCategory);
+    const request = store.add(newCategory);
 
     request.onsuccess = () => {
       const category = {
@@ -47,8 +38,12 @@ export const addCategoryToDB = async (
 };
 
 export const updateCategoryToDB = async (category: TCategory) => {
-  const db = await initDB({ storeName: EStoreName.categoryList });
-  return db.put(category);
+  const db = await openDB();
+  const store = db
+    .transaction(EStoreName.categoryList, ETransactionMode.readwrite)
+    .objectStore(EStoreName.categoryList);
+
+  return store.put(category);
 };
 
 export const deleteCategoryFromDB = async (categoryId: number) => {

--- a/src/features/category-add/category-add.ui.tsx
+++ b/src/features/category-add/category-add.ui.tsx
@@ -1,7 +1,11 @@
 import useCategoryAdd from './category-add.api';
 import styles from './category-add.module.scss';
 
-const CategoryAddButton = () => {
+type TProps = {
+  className?: string;
+};
+
+const CategoryAddButton = ({ className }: TProps) => {
   const { addCategory } = useCategoryAdd();
 
   const handleCategoryAddButtonClick = async () => {
@@ -14,7 +18,7 @@ const CategoryAddButton = () => {
 
   return (
     <button
-      className={styles.addCategoryButton}
+      className={`${styles.addCategoryButton} ${className ?? ''}`}
       onClick={handleCategoryAddButtonClick}
     >
       ➕ 카테고리 추가

--- a/src/features/category-delete/category-delete.hook.ts
+++ b/src/features/category-delete/category-delete.hook.ts
@@ -1,10 +1,5 @@
 import { deleteCategoryFromDB, useCategoryContext } from '@entities/category';
 
-type TArgs = {
-  id?: string;
-  onSuccess?: () => void;
-};
-
 const useCategoryDelete = () => {
   const { categoryList, setCategoryList, setSelectedCategory } =
     useCategoryContext();

--- a/src/features/category-delete/category-delete.ui.tsx
+++ b/src/features/category-delete/category-delete.ui.tsx
@@ -12,7 +12,11 @@ const CategoryDeleteButton = ({ categoryId, categoryTitle }: TProps) => {
   const handleCategoryDeleteButtonClick = () => {
     if (!categoryId) return;
 
-    if (window.confirm(`🚨 '${categoryTitle}'를 영구적으로 삭제합니다.`)) {
+    if (
+      window.confirm(
+        `🚨 '${categoryTitle}'와 모든 태스크를 영구적으로 삭제합니다.`
+      )
+    ) {
       deleteCategory(categoryId);
     }
   };

--- a/src/shared/db/index.ts
+++ b/src/shared/db/index.ts
@@ -11,19 +11,7 @@ export enum EStoreName {
   taskList = 'task_list',
 }
 
-export const initDB = async ({
-  storeName,
-  transactionMode = ETransactionMode.readwrite,
-}: {
-  storeName: EStoreName;
-  transactionMode?: ETransactionMode;
-}) => {
-  const db = await openDB();
-  const store = getObjectStore({ db, storeName, transactionMode });
-  return store;
-};
-
-const openDB = (): Promise<IDBDatabase> => {
+export const openDB = (): Promise<IDBDatabase> => {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
 

--- a/src/widgets/task-section/no-category/ui.module.scss
+++ b/src/widgets/task-section/no-category/ui.module.scss
@@ -3,13 +3,17 @@
 .noCategoryWrapper {
   @include flex(center, center, column);
   @include backgroundStyle;
+  gap: 16px;
 
   .image {
     font-size: 80px;
   }
   .desc {
-    margin-top: 8px;
     text-align: center;
     color: $white;
+  }
+  .categoryAddButton {
+    width: max-content;
+    margin: 0;
   }
 }

--- a/src/widgets/task-section/no-category/ui.tsx
+++ b/src/widgets/task-section/no-category/ui.tsx
@@ -1,3 +1,5 @@
+import { CategoryAddButton } from '@features/category-add';
+
 import styles from './ui.module.scss';
 
 const NoCategory = () => {
@@ -9,6 +11,7 @@ const NoCategory = () => {
         <br />
         태스크를 관리해보세요.
       </div>
+      <CategoryAddButton className={styles.categoryAddButton} />
     </div>
   );
 };


### PR DESCRIPTION
- 카테고리 삭제 시 모든 하위 태스크를 함께 삭제하도록 수정 
  - DB 로직 변경
  - 불필요한 wrapper 함수 제거 
  - 카테고리 삭제 전 window.confirm 안내 문구에 태스크도 함께 삭제 됨을 명시함
- 카테고리가 하나도 없을 때, 화면 중앙 가이드 문구 밑에 카테고리 생성 버튼을 추가함

<br />

## 개발자 테스트

- [x] 카테고리를 삭제하면, 해당 카테고리에 생성한 모든 태스크들이 함께 삭제된다.
  - 개발자 도구 > Application > IndexedDB > db > task_list에서 확인

## 스크린샷

https://github.com/user-attachments/assets/6b110c06-36e2-42f0-bf49-4d06c9e65f59

