### PR TITLE
태스크 생성일에 날짜 형식을 적용하여 표출

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -26,7 +27,8 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vite-tsconfig-paths": "^5.0.1"
+    "vite-tsconfig-paths": "^5.0.1",
+    "vitest": "^2.1.1"
   },
   "packageManager": "pnpm@9.7.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.0.1
         version: 5.0.1(typescript@5.5.4)(vite@5.4.2(sass@1.77.8))
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(sass@1.77.8)
 
 packages:
 
@@ -517,6 +520,36 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
 
+  '@vitest/expect@2.1.1':
+    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
+
+  '@vitest/mocker@2.1.1':
+    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
+    peerDependencies:
+      '@vitest/spy': 2.1.1
+      msw: ^2.3.5
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.1':
+    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
+
+  '@vitest/runner@2.1.1':
+    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
+
+  '@vitest/snapshot@2.1.1':
+    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+
+  '@vitest/spy@2.1.1':
+    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
+
+  '@vitest/utils@2.1.1':
+    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -549,6 +582,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -571,12 +608,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001653:
     resolution: {integrity: sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==}
+
+  chai@5.1.1:
+    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -585,6 +630,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -624,6 +673,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -697,6 +750,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -744,6 +800,9 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -861,8 +920,14 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.1.1:
+    resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.11:
+    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -920,6 +985,13 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
@@ -1001,9 +1073,18 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1023,6 +1104,24 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.0:
+    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
+  tinypool@1.0.1:
+    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -1075,6 +1174,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite-node@2.1.1:
+    resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@5.0.1:
     resolution: {integrity: sha512-yqwv+LstU7NwPeNqajZzLEBVpUFU6Dugtb2P84FXuvaoYA+/70l9MHE+GYfYAycVyPSDYZ7mjOFuYBRqlEpTig==}
     peerDependencies:
@@ -1114,9 +1218,39 @@ packages:
       terser:
         optional: true
 
+  vitest@2.1.1:
+    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.1
+      '@vitest/ui': 2.1.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -1570,6 +1704,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.1':
+    dependencies:
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
+      chai: 5.1.1
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.4.2(sass@1.77.8))':
+    dependencies:
+      '@vitest/spy': 2.1.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.11
+    optionalDependencies:
+      vite: 5.4.2(sass@1.77.8)
+
+  '@vitest/pretty-format@2.1.1':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.1':
+    dependencies:
+      '@vitest/utils': 2.1.1
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.1':
+    dependencies:
+      '@vitest/pretty-format': 2.1.1
+      magic-string: 0.30.11
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.1':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.1':
+    dependencies:
+      '@vitest/pretty-format': 2.1.1
+      loupe: 3.1.1
+      tinyrainbow: 1.2.0
+
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
@@ -1600,6 +1774,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   binary-extensions@2.3.0: {}
@@ -1624,9 +1800,19 @@ snapshots:
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
+  cac@6.7.14: {}
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001653: {}
+
+  chai@5.1.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.1
+      pathval: 2.0.0
 
   chalk@2.4.2:
     dependencies:
@@ -1638,6 +1824,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -1678,6 +1866,8 @@ snapshots:
   debug@4.3.6:
     dependencies:
       ms: 2.1.2
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -1787,6 +1977,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.5
+
   esutils@2.0.3: {}
 
   fast-deep-equal@3.1.3: {}
@@ -1831,6 +2025,8 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-func-name@2.0.2: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -1916,9 +2112,17 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.1.1:
+    dependencies:
+      get-func-name: 2.0.2
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   merge2@1.4.1: {}
 
@@ -1969,6 +2173,10 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.0: {}
 
   picocolors@1.0.1: {}
 
@@ -2052,7 +2260,13 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.7.0: {}
 
   strip-ansi@6.0.1:
     dependencies:
@@ -2069,6 +2283,16 @@ snapshots:
       has-flag: 4.0.0
 
   text-table@0.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.0: {}
+
+  tinypool@1.0.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-fast-properties@2.0.0: {}
 
@@ -2111,6 +2335,23 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite-node@2.1.1(sass@1.77.8):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.6
+      pathe: 1.1.2
+      vite: 5.4.2(sass@1.77.8)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-tsconfig-paths@5.0.1(typescript@5.5.4)(vite@5.4.2(sass@1.77.8)):
     dependencies:
       debug: 4.3.6
@@ -2131,9 +2372,46 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.77.8
 
+  vitest@2.1.1(sass@1.77.8):
+    dependencies:
+      '@vitest/expect': 2.1.1
+      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.4.2(sass@1.77.8))
+      '@vitest/pretty-format': 2.1.1
+      '@vitest/runner': 2.1.1
+      '@vitest/snapshot': 2.1.1
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
+      chai: 5.1.1
+      debug: 4.3.6
+      magic-string: 0.30.11
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.0
+      tinypool: 1.0.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.2(sass@1.77.8)
+      vite-node: 2.1.1(sass@1.77.8)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/reset.scss
+++ b/src/app/reset.scss
@@ -36,6 +36,7 @@ ol[role='list'] {
 body {
   min-height: 100vh;
   line-height: 1.5;
+  font-size: 14px;
 }
 
 /* Set shorter line heights on headings and interactive elements */

--- a/src/features/category-header-show/category-header-show.module.scss
+++ b/src/features/category-header-show/category-header-show.module.scss
@@ -6,7 +6,7 @@
     align-content: center;
     flex: 1;
     margin-right: 16px;
-    font-size: 26px;
+    font-size: 24px;
     color: $white;
   }
 }

--- a/src/features/task-add/task-add.module.scss
+++ b/src/features/task-add/task-add.module.scss
@@ -28,6 +28,7 @@ $inputHeight: 48px;
       border: none;
       background-color: transparent;
       border-radius: inherit;
+      padding: 0;
 
       &:focus {
         outline: none;

--- a/src/shared/date/index.test.ts
+++ b/src/shared/date/index.test.ts
@@ -1,86 +1,41 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterAll } from 'vitest';
 import { formatDateString } from './index';
 
-describe('formatDateString 함수 테스트', () => {
-  it('현재 날짜에 대해 "오늘 hh:MM"을 반환해야 한다', () => {
-    const today = new Date().toISOString();
+describe('formatDateString', () => {
+  const mockDate = (dateString: string) => {
+    const date = new Date(dateString);
+    vi.setSystemTime(date);
+  };
 
-    const utcHours = new Date().getUTCHours().toString().padStart(2, '0');
-    const utcMinutes = new Date().getUTCMinutes().toString().padStart(2, '0');
-    const expectedTime = `${utcHours}:${utcMinutes}`;
-
-    expect(formatDateString(today)).toBe(`오늘 ${expectedTime}`);
+  afterAll(() => {
+    vi.useRealTimers();
   });
 
-  it('어제 날짜에 대해 "어제 hh:MM"을 반환해야 한다', () => {
-    const yesterday = new Date(Date.now() - 86400000).toISOString();
+  it('날짜가 오늘일 때 "오늘"을 반환해야 한다', () => {
+    mockDate('2024-09-23T12:00:00');
 
-    const utcHours = new Date(Date.now() - 86400000)
-      .getUTCHours()
-      .toString()
-      .padStart(2, '0');
-    const utcMinutes = new Date(Date.now() - 86400000)
-      .getUTCMinutes()
-      .toString()
-      .padStart(2, '0');
-    const expectedTime = `${utcHours}:${utcMinutes}`;
-
-    expect(formatDateString(yesterday)).toBe(`어제 ${expectedTime}`);
+    const result = formatDateString('2024-09-23T10:30:00');
+    expect(result).toBe('오늘 10:30');
   });
 
-  it('내일 날짜에 대해 "내일 hh:MM"을 반환해야 한다', () => {
-    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+  it('날짜가 어제일 때 "어제"를 반환해야 한다', () => {
+    mockDate('2024-09-23T12:00:00');
 
-    const utcHours = new Date(Date.now() + 86400000)
-      .getUTCHours()
-      .toString()
-      .padStart(2, '0');
-    const utcMinutes = new Date(Date.now() + 86400000)
-      .getUTCMinutes()
-      .toString()
-      .padStart(2, '0');
-    const expectedTime = `${utcHours}:${utcMinutes}`;
-
-    expect(formatDateString(tomorrow)).toBe(`내일 ${expectedTime}`);
+    const result = formatDateString('2024-09-22T10:30:00');
+    expect(result).toBe('어제 10:30');
   });
 
-  it('오늘, 어제, 내일이 아닌 날짜에 대해 "x월 x일 요일 hh:MM" 형식의 날짜를 반환해야 한다', () => {
-    const testDate = new Date('2023-09-20T15:30:00.000Z').toISOString();
+  it('날짜가 내일일 때 "내일"을 반환해야 한다', () => {
+    mockDate('2024-09-23T12:00:00');
 
-    expect(formatDateString(testDate)).toBe('9월 20일 수 15:30');
+    const result = formatDateString('2024-09-24T10:30:00');
+    expect(result).toBe('내일 10:30');
   });
 
-  it('자정에 가까운 경계 조건을 정확히 처리해야 한다', () => {
-    const lateNightYesterday = new Date(
-      Date.now() - (86400000 - 1000)
-    ).toISOString(); // 어제 23:59:59
-    const earlyMorningTomorrow = new Date(
-      Date.now() + (86400000 + 1000)
-    ).toISOString(); // 내일 00:00:01
+  it('날짜가 오늘, 어제, 내일이 아닐 때 포맷된 날짜를 반환해야 한다', () => {
+    mockDate('2024-09-23T12:00:00');
 
-    const lateNightHours = new Date(Date.now() - (86400000 - 1000))
-      .getUTCHours()
-      .toString()
-      .padStart(2, '0');
-    const lateNightMinutes = new Date(Date.now() - (86400000 - 1000))
-      .getUTCMinutes()
-      .toString()
-      .padStart(2, '0');
-
-    const earlyMorningHours = new Date(Date.now() + (86400000 + 1000))
-      .getUTCHours()
-      .toString()
-      .padStart(2, '0');
-    const earlyMorningMinutes = new Date(Date.now() + (86400000 + 1000))
-      .getUTCMinutes()
-      .toString()
-      .padStart(2, '0');
-
-    expect(formatDateString(lateNightYesterday)).toBe(
-      `어제 ${lateNightHours}:${lateNightMinutes}`
-    );
-    expect(formatDateString(earlyMorningTomorrow)).toBe(
-      `내일 ${earlyMorningHours}:${earlyMorningMinutes}`
-    );
+    const result = formatDateString('2024-09-20T10:30:00');
+    expect(result).toBe('9월 20일 금 10:30');
   });
 });

--- a/src/shared/date/index.test.ts
+++ b/src/shared/date/index.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { formatDateString } from './index';
+
+describe('formatDateString 함수 테스트', () => {
+  it('현재 날짜에 대해 "오늘 hh:MM"을 반환해야 한다', () => {
+    const today = new Date().toISOString();
+
+    const utcHours = new Date().getUTCHours().toString().padStart(2, '0');
+    const utcMinutes = new Date().getUTCMinutes().toString().padStart(2, '0');
+    const expectedTime = `${utcHours}:${utcMinutes}`;
+
+    expect(formatDateString(today)).toBe(`오늘 ${expectedTime}`);
+  });
+
+  it('어제 날짜에 대해 "어제 hh:MM"을 반환해야 한다', () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+
+    const utcHours = new Date(Date.now() - 86400000)
+      .getUTCHours()
+      .toString()
+      .padStart(2, '0');
+    const utcMinutes = new Date(Date.now() - 86400000)
+      .getUTCMinutes()
+      .toString()
+      .padStart(2, '0');
+    const expectedTime = `${utcHours}:${utcMinutes}`;
+
+    expect(formatDateString(yesterday)).toBe(`어제 ${expectedTime}`);
+  });
+
+  it('내일 날짜에 대해 "내일 hh:MM"을 반환해야 한다', () => {
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+
+    const utcHours = new Date(Date.now() + 86400000)
+      .getUTCHours()
+      .toString()
+      .padStart(2, '0');
+    const utcMinutes = new Date(Date.now() + 86400000)
+      .getUTCMinutes()
+      .toString()
+      .padStart(2, '0');
+    const expectedTime = `${utcHours}:${utcMinutes}`;
+
+    expect(formatDateString(tomorrow)).toBe(`내일 ${expectedTime}`);
+  });
+
+  it('오늘, 어제, 내일이 아닌 날짜에 대해 "x월 x일 요일 hh:MM" 형식의 날짜를 반환해야 한다', () => {
+    const testDate = new Date('2023-09-20T15:30:00.000Z').toISOString();
+
+    expect(formatDateString(testDate)).toBe('9월 20일 수 15:30');
+  });
+
+  it('자정에 가까운 경계 조건을 정확히 처리해야 한다', () => {
+    const lateNightYesterday = new Date(
+      Date.now() - (86400000 - 1000)
+    ).toISOString(); // 어제 23:59:59
+    const earlyMorningTomorrow = new Date(
+      Date.now() + (86400000 + 1000)
+    ).toISOString(); // 내일 00:00:01
+
+    const lateNightHours = new Date(Date.now() - (86400000 - 1000))
+      .getUTCHours()
+      .toString()
+      .padStart(2, '0');
+    const lateNightMinutes = new Date(Date.now() - (86400000 - 1000))
+      .getUTCMinutes()
+      .toString()
+      .padStart(2, '0');
+
+    const earlyMorningHours = new Date(Date.now() + (86400000 + 1000))
+      .getUTCHours()
+      .toString()
+      .padStart(2, '0');
+    const earlyMorningMinutes = new Date(Date.now() + (86400000 + 1000))
+      .getUTCMinutes()
+      .toString()
+      .padStart(2, '0');
+
+    expect(formatDateString(lateNightYesterday)).toBe(
+      `어제 ${lateNightHours}:${lateNightMinutes}`
+    );
+    expect(formatDateString(earlyMorningTomorrow)).toBe(
+      `내일 ${earlyMorningHours}:${earlyMorningMinutes}`
+    );
+  });
+});

--- a/src/shared/date/index.ts
+++ b/src/shared/date/index.ts
@@ -1,0 +1,38 @@
+export const formatDateString = (dateString: string): string => {
+  const days = ['일', '월', '화', '수', '목', '금', '토'];
+  const inputDate = new Date(dateString);
+  const today = new Date();
+
+  // UTC 기준으로 시간 포맷: hh:MM
+  const hours = inputDate.getUTCHours().toString().padStart(2, '0');
+  const minutes = inputDate.getUTCMinutes().toString().padStart(2, '0');
+  const timeString = `${hours}:${minutes}`;
+
+  const isToday =
+    today.toISOString().slice(0, 10) === inputDate.toISOString().slice(0, 10);
+
+  const yesterday = new Date(today);
+  yesterday.setUTCDate(today.getUTCDate() - 1);
+  const isYesterday =
+    yesterday.toISOString().slice(0, 10) ===
+    inputDate.toISOString().slice(0, 10);
+
+  const tomorrow = new Date(today);
+  tomorrow.setUTCDate(today.getUTCDate() + 1);
+  const isTomorrow =
+    tomorrow.toISOString().slice(0, 10) ===
+    inputDate.toISOString().slice(0, 10);
+
+  if (isToday) {
+    return `오늘 ${timeString}`;
+  } else if (isYesterday) {
+    return `어제 ${timeString}`;
+  } else if (isTomorrow) {
+    return `내일 ${timeString}`;
+  } else {
+    const month = inputDate.getUTCMonth() + 1;
+    const date = inputDate.getUTCDate();
+    const dayOfWeek = days[inputDate.getUTCDay()];
+    return `${month}월 ${date}일 ${dayOfWeek} ${timeString}`;
+  }
+};

--- a/src/shared/date/index.ts
+++ b/src/shared/date/index.ts
@@ -3,25 +3,22 @@ export const formatDateString = (dateString: string): string => {
   const inputDate = new Date(dateString);
   const today = new Date();
 
-  // UTC 기준으로 시간 포맷: hh:MM
-  const hours = inputDate.getUTCHours().toString().padStart(2, '0');
-  const minutes = inputDate.getUTCMinutes().toString().padStart(2, '0');
+  // 현지 시간 기준으로 시간 포맷: hh:mm
+  const hours = inputDate.getHours().toString().padStart(2, '0');
+  const minutes = inputDate.getMinutes().toString().padStart(2, '0');
   const timeString = `${hours}:${minutes}`;
 
-  const isToday =
-    today.toISOString().slice(0, 10) === inputDate.toISOString().slice(0, 10);
+  const isToday = today.toLocaleDateString() === inputDate.toLocaleDateString();
 
   const yesterday = new Date(today);
-  yesterday.setUTCDate(today.getUTCDate() - 1);
+  yesterday.setDate(today.getDate() - 1);
   const isYesterday =
-    yesterday.toISOString().slice(0, 10) ===
-    inputDate.toISOString().slice(0, 10);
+    yesterday.toLocaleDateString() === inputDate.toLocaleDateString();
 
   const tomorrow = new Date(today);
-  tomorrow.setUTCDate(today.getUTCDate() + 1);
+  tomorrow.setDate(today.getDate() + 1);
   const isTomorrow =
-    tomorrow.toISOString().slice(0, 10) ===
-    inputDate.toISOString().slice(0, 10);
+    tomorrow.toLocaleDateString() === inputDate.toLocaleDateString();
 
   if (isToday) {
     return `오늘 ${timeString}`;
@@ -30,9 +27,9 @@ export const formatDateString = (dateString: string): string => {
   } else if (isTomorrow) {
     return `내일 ${timeString}`;
   } else {
-    const month = inputDate.getUTCMonth() + 1;
-    const date = inputDate.getUTCDate();
-    const dayOfWeek = days[inputDate.getUTCDay()];
+    const month = inputDate.getMonth() + 1;
+    const date = inputDate.getDate();
+    const dayOfWeek = days[inputDate.getDay()];
     return `${month}월 ${date}일 ${dayOfWeek} ${timeString}`;
   }
 };

--- a/src/widgets/task-detail/task-detail.module.scss
+++ b/src/widgets/task-detail/task-detail.module.scss
@@ -31,7 +31,7 @@ $detailWidth: 360px;
       @include flex(start, center);
       @include boxStyle;
       gap: 8px;
-      font-size: 18px;
+      font-size: 16px;
       font-weight: 600;
 
       .isCompleted {

--- a/src/widgets/task-detail/task-detail.ui.tsx
+++ b/src/widgets/task-detail/task-detail.ui.tsx
@@ -3,8 +3,9 @@ import { TaskDeleteButton } from '@features/task-delete';
 
 import { TTask } from '@entities/task';
 
-import styles from './task-detail.module.scss';
 import { formatDateString } from '@shared/date';
+
+import styles from './task-detail.module.scss';
 
 type TProps = Omit<TTask, 'categoryId'>;
 

--- a/src/widgets/task-detail/task-detail.ui.tsx
+++ b/src/widgets/task-detail/task-detail.ui.tsx
@@ -4,6 +4,7 @@ import { TaskDeleteButton } from '@features/task-delete';
 import { TTask } from '@entities/task';
 
 import styles from './task-detail.module.scss';
+import { formatDateString } from '@shared/date';
 
 type TProps = Omit<TTask, 'categoryId'>;
 
@@ -41,7 +42,9 @@ const TaskDetail = ({
         </textarea>
       </div>
       <div className={styles.bottomToolbar}>
-        <div className={styles.createdAt}>{createdAt}</div>
+        <div className={styles.createdAt}>{`${formatDateString(
+          createdAt
+        )}에 생성됨`}</div>
         <TaskDeleteButton id={id} />
       </div>
     </div>


### PR DESCRIPTION
## 변경사항

- 태스크 생성일에 날짜 형식을 적용하여 표출하도록 수정
  - `어제`, `오늘`, `내일`, `m월 d일 a hh:mm`
  - 현지 시간에 맞게 변환
- vitest 설정
  - 테스트 코드 추가 
- 전체적으로 폰트 사이즈를 축소 

<br />

## 테스트 방법

1. 태스크를 생성한다.
2. 생성한 태스크를 클릭해 태스크 상세보기 패널을 조회한다.
3. 상세보기 패널 하단의 태스크 생성일이 `오늘 hh:mm에 생성됨` 형태로 보여진다.

![image](https://github.com/user-attachments/assets/364ec38c-a96e-4582-8555-faade23f8c15)

<br />

## 스크린샷

[전]

![image](https://github.com/user-attachments/assets/36410364-38d6-4dd0-8705-8c67f99144ae)

[후]

![image](https://github.com/user-attachments/assets/853e6512-6943-40ac-881f-ed8060ab8b2d)

