### PR TITLE
카테고리 관련 API 추가, 테스트 호출

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,12 +14,15 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",
+    "@tanstack/react-query": "^5.59.16",
+    "@tanstack/react-query-devtools": "^5.59.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@playwright/test": "^1.48.0",
+    "@tanstack/eslint-plugin-query": "^5.59.7",
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/client/src/app/providers/index.tsx
+++ b/client/src/app/providers/index.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import { CategoryProvider } from '@entities/category';
 import { TaskProvider } from '@entities/task';
 
+const queryClient = new QueryClient();
+
 const Providers = ({ children }: { children: React.ReactNode }) => {
   return (
-    <CategoryProvider>
-      <TaskProvider>{children}</TaskProvider>
-    </CategoryProvider>
+    <QueryClientProvider client={queryClient}>
+      <CategoryProvider>
+        <TaskProvider>{children}</TaskProvider>
+      </CategoryProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 };
 

--- a/client/src/pages/main/main.api.ts
+++ b/client/src/pages/main/main.api.ts
@@ -1,0 +1,4 @@
+export const fetchCategories = async () => {
+  const response = await fetch('http://localhost:3000/categories');
+  return response.json();
+};

--- a/client/src/pages/main/main.ui.tsx
+++ b/client/src/pages/main/main.ui.tsx
@@ -9,8 +9,21 @@ import { useCategoryContext } from '@entities/category';
 import { useTaskContext } from '@entities/task';
 
 import styles from './main.module.scss';
+import { useQuery } from '@tanstack/react-query';
+import { fetchCategories } from './main.api';
 
 const MainPage = () => {
+  const {
+    data: categoryList,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ['categories'],
+    queryFn: fetchCategories,
+  });
+
+  console.log(categoryList, isPending, isError);
+
   const { selectedCategory } = useCategoryContext();
   const { selectedTask } = useTaskContext();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,12 @@ importers:
       '@heroicons/react':
         specifier: ^2.1.5
         version: 2.1.5(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.59.16
+        version: 5.59.16(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.59.16
+        version: 5.59.16(@tanstack/react-query@5.59.16(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -26,6 +32,9 @@ importers:
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.48.1
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.59.7
+        version: 5.59.7(eslint@9.13.0)(typescript@5.6.3)
       '@types/node':
         specifier: ^22.7.5
         version: 22.7.9
@@ -74,6 +83,9 @@ importers:
       cookie-parser:
         specifier: ~1.4.4
         version: 1.4.7
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       debug:
         specifier: ~2.6.9
         version: 2.6.9
@@ -567,6 +579,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tanstack/eslint-plugin-query@5.59.7':
+    resolution: {integrity: sha512-txQGX5yC+4gmbR81EXaum2tOxeDQkRCWnaLmaP/pSrbIVCUkbMbrxxsaoOgN+fBqqqGo9V3LoCVL6ez1tRUF7Q==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
+  '@tanstack/query-core@5.59.16':
+    resolution: {integrity: sha512-crHn+G3ltqb5JG0oUv6q+PMz1m1YkjpASrXTU+sYWW9pLk0t2GybUHNRqYPZWhxgjPaVGC4yp92gSFEJgYEsPw==}
+
+  '@tanstack/query-devtools@5.58.0':
+    resolution: {integrity: sha512-iFdQEFXaYYxqgrv63ots+65FGI+tNp5ZS5PdMU1DWisxk3fez5HG3FyVlbUva+RdYS5hSLbxZ9aw3yEs97GNTw==}
+
+  '@tanstack/react-query-devtools@5.59.16':
+    resolution: {integrity: sha512-Dejo39QBXmDqXZ3vdrk7vHDvs7TvL573/AX2NveMBmRAufAPYuE3oWSKP/gGqkDfEqyr4CmldOj+v9cKskUchQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.59.16
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.59.16':
+    resolution: {integrity: sha512-MuyWheG47h6ERd4PKQ6V8gDyBu3ThNG22e1fRVwvq6ap3EqsFhyuxCAwhNP/03m/mLg+DAb0upgbPaX6VB+CkQ==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -882,6 +916,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -1330,6 +1368,10 @@ packages:
 
   node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -2168,6 +2210,29 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
+  '@tanstack/eslint-plugin-query@5.59.7(eslint@9.13.0)(typescript@5.6.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0)(typescript@5.6.3)
+      eslint: 9.13.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@tanstack/query-core@5.59.16': {}
+
+  '@tanstack/query-devtools@5.58.0': {}
+
+  '@tanstack/react-query-devtools@5.59.16(@tanstack/react-query@5.59.16(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.58.0
+      '@tanstack/react-query': 5.59.16(react@18.3.1)
+      react: 18.3.1
+
+  '@tanstack/react-query@5.59.16(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.59.16
+      react: 18.3.1
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.25.9
@@ -2524,6 +2589,11 @@ snapshots:
   cookie@0.3.1: {}
 
   cookie@0.7.2: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.3:
     dependencies:
@@ -2975,6 +3045,8 @@ snapshots:
   node-addon-api@7.1.1: {}
 
   node-releases@2.0.18: {}
+
+  object-assign@4.1.1: {}
 
   on-finished@2.3.0:
     dependencies:

--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,11 +1,12 @@
 var createError = require('http-errors');
 var express = require('express');
+var cors = require('cors');
 var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
-var categoryRouter = require('./routes/category');
+var categoriesRouter = require('./routes/categories');
 
 var app = express();
 
@@ -16,6 +17,7 @@ app.set('view engine', 'jade');
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(cors({ origin: 'http://localhost:5173' }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/server/app.js
+++ b/server/app.js
@@ -5,7 +5,7 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
-var usersRouter = require('./routes/users');
+var categoryRouter = require('./routes/category');
 
 var app = express();
 
@@ -20,15 +20,15 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
-app.use('/users', usersRouter);
+app.use('/category', categoryRouter);
 
 // catch 404 and forward to error handler
-app.use(function(req, res, next) {
+app.use(function (req, res, next) {
   next(createError(404));
 });
 
 // error handler
-app.use(function(err, req, res, next) {
+app.use(function (err, req, res, next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};

--- a/server/app.js
+++ b/server/app.js
@@ -22,7 +22,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
-app.use('/category', categoryRouter);
+app.use('/categories', categoriesRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "express": "~4.16.1",
     "http-errors": "~1.6.3",

--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -1,37 +1,39 @@
-var express = require("express");
+var express = require('express');
 var router = express.Router();
 
-const categoryList = [];
+const categoryList = [
+  { id: '1', name: '카테고리1' },
+  { id: '2', name: '카테고리2' },
+];
 
-// todo: client에서 react-query + axios로 api 호출해보기
-router.get("/categories", function (req, res, next) {
+router.get('/', function (req, res, next) {
   res.json(categoryList);
 });
 
-router.get("/categories/:categoryId", function (req, res, next) {
+router.get('/:categoryId', function (req, res, next) {
   const categoryId = req.params.categoryId;
   const category = categoryList.find((category) => category.id === categoryId);
 
   if (!category) {
-    res.status(404).json({ message: "Category not found" });
+    res.status(404).json({ message: 'Category not found' });
     return;
   }
 
   res.json(category);
 });
 
-router.post("/categories", function (req, res, next) {
+router.post('/', function (req, res, next) {
   const newCategory = req.body;
   categoryList.push(newCategory);
   res.status(201).json(newCategory);
 });
 
-router.put("/categories/:categoryId", function (req, res, next) {
+router.put('/:categoryId', function (req, res, next) {
   const categoryId = req.params.categoryId;
   const category = categoryList.find((category) => category.id === categoryId);
 
   if (!category) {
-    res.status(404).json({ message: "Category not found" });
+    res.status(404).json({ message: 'Category not found' });
     return;
   }
 
@@ -41,12 +43,12 @@ router.put("/categories/:categoryId", function (req, res, next) {
   res.json(updatedCategory);
 });
 
-router.delete("/categories/:categoryId", function (req, res, next) {
+router.delete('/:categoryId', function (req, res, next) {
   const categoryId = req.params.categoryId;
   const category = categoryList.find((category) => category.id === categoryId);
 
   if (!category) {
-    res.status(404).json({ message: "Category not found" });
+    res.status(404).json({ message: 'Category not found' });
     return;
   }
 

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -1,0 +1,58 @@
+var express = require("express");
+var router = express.Router();
+
+const categoryList = [];
+
+// todo: client에서 react-query + axios로 api 호출해보기
+router.get("/categories", function (req, res, next) {
+  res.json(categoryList);
+});
+
+router.get("/categories/:categoryId", function (req, res, next) {
+  const categoryId = req.params.categoryId;
+  const category = categoryList.find((category) => category.id === categoryId);
+
+  if (!category) {
+    res.status(404).json({ message: "Category not found" });
+    return;
+  }
+
+  res.json(category);
+});
+
+router.post("/categories", function (req, res, next) {
+  const newCategory = req.body;
+  categoryList.push(newCategory);
+  res.status(201).json(newCategory);
+});
+
+router.put("/categories/:categoryId", function (req, res, next) {
+  const categoryId = req.params.categoryId;
+  const category = categoryList.find((category) => category.id === categoryId);
+
+  if (!category) {
+    res.status(404).json({ message: "Category not found" });
+    return;
+  }
+
+  const updatedCategory = req.body;
+  categoryList[categoryList.indexOf(category)] = updatedCategory;
+
+  res.json(updatedCategory);
+});
+
+router.delete("/categories/:categoryId", function (req, res, next) {
+  const categoryId = req.params.categoryId;
+  const category = categoryList.find((category) => category.id === categoryId);
+
+  if (!category) {
+    res.status(404).json({ message: "Category not found" });
+    return;
+  }
+
+  categoryList.splice(categoryList.indexOf(category), 1);
+
+  res.json(category);
+});
+
+module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET users listing. */
-router.get('/', function(req, res, next) {
-  res.send('respond with a resource');
-});
-
-module.exports = router;


### PR DESCRIPTION
## 변경 사항

- API 통신을 위한 패키지 설치와 설정
  - client: [@tanstack/react-query](https://tanstack.com/query/latest/docs/framework/react/overview)
  - server: [cors](https://github.com/expressjs/cors)
- 카테고리 관련 API 추가
  - server/routes/categories
- 카테고리 목록 API 호출 테스트 임시 코드 추가

## 테스트 방법

1. pnpm dev
2. localhost:5173
3. 개발자 도구 > Network 에서 API 호출 내역 확인

## 스크린샷

https://github.com/user-attachments/assets/9a9a1a91-700d-4df7-96f4-c8829371bc2f


